### PR TITLE
Added missing r-oxygen param include_all_confidence_scores

### DIFF
--- a/R/ner-dl.R
+++ b/R/ner-dl.R
@@ -221,6 +221,7 @@ new_nlp_ner_dl_model <- function(jobj) {
 #' @template roxlate-pretrained-params
 #' @template roxlate-inputs-output-params
 #' @param include_confidence whether to include confidence values
+#' @param include_all_confidence_scores whether to include all confidence scores in annotation metadata or just score of the predicted tag (boolean)
 #' @export
 nlp_ner_dl_pretrained <- function(sc, input_cols, output_col, include_confidence = NULL,
                                   include_all_confidence_scores = NULL, name = NULL, lang = NULL, remote_loc = NULL) {


### PR DESCRIPTION
In the nlp_ner_dl_pretrained function, the include_all_confidence_scores parameter is missing in the documentation. When I checked the code for it, it's actually missing from the documentation param. Added it here to fix it.